### PR TITLE
Feature/Signin, Signup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -39,7 +38,6 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -38,6 +40,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -22,13 +22,24 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	compileOnly 'org.projectlombok:lombok'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'com.auth0:java-jwt:3.4.1'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/C1S/childgoodsstore/entity/BaseEntity.java
+++ b/src/main/java/C1S/childgoodsstore/entity/BaseEntity.java
@@ -1,0 +1,38 @@
+package C1S.childgoodsstore.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt() {
+        this.createdAt = LocalDateTime.now().withNano(0);
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt() {
+        this.updatedAt = LocalDateTime.now().withNano(0);
+    }
+}

--- a/src/main/java/C1S/childgoodsstore/entity/ROLE.java
+++ b/src/main/java/C1S/childgoodsstore/entity/ROLE.java
@@ -1,0 +1,10 @@
+package C1S.childgoodsstore.entity;
+
+/**
+ * USER: 기본 서비스 회원가입을 하거나, 소셜 로그인으로 회원가입 까지 한 상태
+ * ADMIN: 관리자
+ * */
+public enum ROLE {
+
+    USER, ADMIN
+}

--- a/src/main/java/C1S/childgoodsstore/entity/User.java
+++ b/src/main/java/C1S/childgoodsstore/entity/User.java
@@ -40,4 +40,6 @@ public class User extends BaseEntity {
         setCreatedAt();
         setUpdatedAt();
     }
+
+
 }

--- a/src/main/java/C1S/childgoodsstore/entity/User.java
+++ b/src/main/java/C1S/childgoodsstore/entity/User.java
@@ -19,10 +19,25 @@ public class User extends BaseEntity {
     private String nickName;
     private String introduce;
     private String profileImg;
-    private String phoneNum;
+    private String phone;
     private String region;
     private String town;
     private String state;
     private Integer totalScore;
     private Integer scoreNum;
+    @Enumerated(EnumType.STRING)
+    private ROLE role;
+
+    public User() {
+
+    }
+
+    public User(String email, String password, String phone, ROLE role){
+        this.email = email;
+        this.password = password;
+        this.phone = phone;
+        this.role = role;
+        setCreatedAt();
+        setUpdatedAt();
+    }
 }

--- a/src/main/java/C1S/childgoodsstore/entity/User.java
+++ b/src/main/java/C1S/childgoodsstore/entity/User.java
@@ -1,4 +1,28 @@
 package C1S.childgoodsstore.entity;
 
-public class User {
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    private String email;
+    private String password;
+    private String nickName;
+    private String introduce;
+    private String profileImg;
+    private String phoneNum;
+    private String region;
+    private String town;
+    private String state;
+    private Integer totalScore;
+    private Integer scoreNum;
 }

--- a/src/main/java/C1S/childgoodsstore/security/CorsConfig.java
+++ b/src/main/java/C1S/childgoodsstore/security/CorsConfig.java
@@ -1,0 +1,25 @@
+package C1S.childgoodsstore.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*"); // e.g. http://domain1.com
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/user/**", config);
+        return new CorsFilter(source);
+    }
+
+}

--- a/src/main/java/C1S/childgoodsstore/security/auth/PrincipalDetails.java
+++ b/src/main/java/C1S/childgoodsstore/security/auth/PrincipalDetails.java
@@ -1,0 +1,57 @@
+package C1S.childgoodsstore.security.auth;
+
+import lombok.Data;
+import C1S.childgoodsstore.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Data
+public class PrincipalDetails implements UserDetails {
+    private User user;
+
+    public PrincipalDetails(User user) {
+        this.user = user;
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(user.getRole().toString()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/C1S/childgoodsstore/security/auth/PrincipalDetailsService.java
+++ b/src/main/java/C1S/childgoodsstore/security/auth/PrincipalDetailsService.java
@@ -1,0 +1,25 @@
+package C1S.childgoodsstore.security.auth;
+
+import lombok.RequiredArgsConstructor;
+import C1S.childgoodsstore.entity.User;
+import C1S.childgoodsstore.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+// /login 일 때 동작
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userEmail) throws UsernameNotFoundException {
+        User userEntity = userRepository.findByEmail(userEmail).orElseThrow(() -> {
+            throw new UsernameNotFoundException("User not found with email: " + userEmail);
+        });
+
+        return new PrincipalDetails(userEntity);
+    }
+}

--- a/src/main/java/C1S/childgoodsstore/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/C1S/childgoodsstore/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package C1S.childgoodsstore.security.jwt;
+
+import C1S.childgoodsstore.util.ApiResponse;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import C1S.childgoodsstore.security.auth.PrincipalDetails;
+import C1S.childgoodsstore.entity.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Date;
+
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        ObjectMapper om = new ObjectMapper();
+        User user = null;
+
+        try {
+            user = om.readValue(request.getInputStream(), User.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(user.getEmail(), user.getPassword());
+
+        //PrincipalDetailsService의 loadUserByUsername() 함수가 실행됨
+        Authentication authentication =
+                authenticationManager.authenticate(authenticationToken);
+
+        return authentication;
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        PrincipalDetails principalDetails = (PrincipalDetails) authResult.getPrincipal();
+
+        String jwtToken = JWT.create()
+                .withSubject(principalDetails.getUsername())
+                .withExpiresAt(new Date(System.currentTimeMillis()+JwtProperties.EXPIRATION_TIME))
+                .withClaim("id", principalDetails.getUser().getUserId())
+                .withClaim("email", principalDetails.getUser().getEmail())
+                .sign(Algorithm.HMAC512(JwtProperties.SECRET));
+
+        ApiResponse<String> apiResponse = new ApiResponse<>(String.valueOf(HttpStatus.OK.value()), jwtToken);
+
+        // JSON 형태로 변환하여 응답 바디에 추가
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/C1S/childgoodsstore/security/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/C1S/childgoodsstore/security/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,64 @@
+package C1S.childgoodsstore.security.jwt;
+
+import C1S.childgoodsstore.util.exception.CustomException;
+import C1S.childgoodsstore.util.exception.ErrorCode;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import C1S.childgoodsstore.security.auth.PrincipalDetails;
+import C1S.childgoodsstore.entity.User;
+import C1S.childgoodsstore.user.repository.UserRepository;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
+
+    private UserRepository userRepository;
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, UserRepository userRepository) {
+        super(authenticationManager);
+        this.userRepository = userRepository;
+    }
+
+    //인증이나 권한이 필요한 주소 요청 왔을 때
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        String jwtHeader = request.getHeader("Authorization");
+
+        if (jwtHeader == null || !jwtHeader.startsWith(JwtProperties.TOKEN_PREFIX)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        String token = request.getHeader(JwtProperties.HEADER_STRING)
+                .replace(JwtProperties.TOKEN_PREFIX, "");
+
+        String userEmail = JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
+                .getClaim("email").asString();
+
+        if (userEmail != null) {
+            User user = userRepository.findByEmail(userEmail).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+            PrincipalDetails principalDetails = new PrincipalDetails(user);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    principalDetails,
+                    null,
+                    principalDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+
+    }
+
+}

--- a/src/main/java/C1S/childgoodsstore/security/jwt/JwtProperties.java
+++ b/src/main/java/C1S/childgoodsstore/security/jwt/JwtProperties.java
@@ -1,0 +1,8 @@
+package C1S.childgoodsstore.security.jwt;
+
+public interface JwtProperties {
+    String SECRET = "wecan"; // 우리 서버만 알고 있는 비밀값
+    int EXPIRATION_TIME = 864000000; // 10일 (1/1000초)
+    String TOKEN_PREFIX = "Bearer ";
+    String HEADER_STRING = "Authorization";
+}

--- a/src/main/java/C1S/childgoodsstore/security/securityConfig.java
+++ b/src/main/java/C1S/childgoodsstore/security/securityConfig.java
@@ -1,0 +1,60 @@
+package C1S.childgoodsstore.security;
+
+import C1S.childgoodsstore.security.jwt.JwtAuthenticationFilter;
+import C1S.childgoodsstore.security.jwt.JwtAuthorizationFilter;
+import C1S.childgoodsstore.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity // 스프링 시큐리티 필터(security Config)가 스프링 필터 체인에 등록 된다.
+@RequiredArgsConstructor
+public class securityConfig {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private final CorsConfig corsConfig;
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder sharedObject = http.getSharedObject(AuthenticationManagerBuilder.class);
+        AuthenticationManager authenticationManager = sharedObject.build();
+
+        http.authenticationManager(authenticationManager);
+
+        http
+                .addFilter(corsConfig.corsFilter())
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                .formLogin(login -> login.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+
+                .addFilter(new JwtAuthenticationFilter(authenticationManager))
+                .addFilter(new JwtAuthorizationFilter(authenticationManager, userRepository))
+
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/user/**").hasRole("USER")
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .anyRequest().permitAll()
+                );
+        return http.build();
+    }
+
+}

--- a/src/main/java/C1S/childgoodsstore/user/controller/UserController.java
+++ b/src/main/java/C1S/childgoodsstore/user/controller/UserController.java
@@ -1,4 +1,17 @@
 package C1S.childgoodsstore.user.controller;
 
+import C1S.childgoodsstore.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import C1S.childgoodsstore.util.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@CrossOrigin(origins = "*", allowedHeaders = "*")
 public class UserController {
+
+    private final UserService userService;
+
 }

--- a/src/main/java/C1S/childgoodsstore/user/controller/UserController.java
+++ b/src/main/java/C1S/childgoodsstore/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package C1S.childgoodsstore.user.controller;
 
+import C1S.childgoodsstore.user.dto.SignUpDto;
 import C1S.childgoodsstore.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +10,12 @@ import C1S.childgoodsstore.util.ApiResponse;
 
 @RestController
 @RequiredArgsConstructor
-@CrossOrigin(origins = "*", allowedHeaders = "*")
 public class UserController {
 
     private final UserService userService;
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Long>> signUpUser(@Valid @RequestBody SignUpDto signUpDto) {
+        return ResponseEntity.ok().body(ApiResponse.success(userService.save(signUpDto)));
+    }
 
 }

--- a/src/main/java/C1S/childgoodsstore/user/dto/SignUpDto.java
+++ b/src/main/java/C1S/childgoodsstore/user/dto/SignUpDto.java
@@ -1,0 +1,27 @@
+package C1S.childgoodsstore.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+public class SignUpDto {
+    @NotNull(message = "이메일이 null 입니다.")
+    @Email
+    private final String email;
+
+    @NotNull(message = "비밀번호가 null 입니다.")
+    private final String password;
+
+    @NotNull
+    @Pattern(regexp = "^01(?:0|1|[6-9])[.-]?(\\d{3}|\\d{4})[.-]?(\\d{4})$", message = "10 ~ 11 자리의 숫자만 입력 가능합니다.")
+    private final String phone;
+
+}

--- a/src/main/java/C1S/childgoodsstore/user/repository/UserRepository.java
+++ b/src/main/java/C1S/childgoodsstore/user/repository/UserRepository.java
@@ -1,4 +1,11 @@
 package C1S.childgoodsstore.user.repository;
 
-public class UserRepository {
+import C1S.childgoodsstore.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
 }

--- a/src/main/java/C1S/childgoodsstore/user/repository/UserRepository.java
+++ b/src/main/java/C1S/childgoodsstore/user/repository/UserRepository.java
@@ -4,8 +4,10 @@ import C1S.childgoodsstore.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/C1S/childgoodsstore/user/service/UserService.java
+++ b/src/main/java/C1S/childgoodsstore/user/service/UserService.java
@@ -8,6 +8,7 @@ import C1S.childgoodsstore.util.exception.CustomException;
 import C1S.childgoodsstore.util.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -18,6 +19,7 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public Long save(SignUpDto signUpDto) {
 
@@ -26,7 +28,7 @@ public class UserService {
         if(!findUser.isEmpty())
             throw new CustomException(ErrorCode.USER_EMAIL_DUPLICATED);
 
-        User savedUser = userRepository.saveAndFlush(new User(signUpDto.getEmail(), signUpDto.getPassword(), signUpDto.getPhone(), ROLE.USER));
+        User savedUser = userRepository.saveAndFlush(new User(signUpDto.getEmail(), bCryptPasswordEncoder.encode(signUpDto.getPassword()), signUpDto.getPhone(), ROLE.USER));
 
         return savedUser.getUserId();
     }

--- a/src/main/java/C1S/childgoodsstore/user/service/UserService.java
+++ b/src/main/java/C1S/childgoodsstore/user/service/UserService.java
@@ -1,4 +1,14 @@
 package C1S.childgoodsstore.user.service;
 
+import C1S.childgoodsstore.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
 public class UserService {
+
+    private final UserRepository userRepository;
 }

--- a/src/main/java/C1S/childgoodsstore/user/service/UserService.java
+++ b/src/main/java/C1S/childgoodsstore/user/service/UserService.java
@@ -1,9 +1,16 @@
 package C1S.childgoodsstore.user.service;
 
+import C1S.childgoodsstore.entity.ROLE;
+import C1S.childgoodsstore.entity.User;
+import C1S.childgoodsstore.user.dto.SignUpDto;
 import C1S.childgoodsstore.user.repository.UserRepository;
+import C1S.childgoodsstore.util.exception.CustomException;
+import C1S.childgoodsstore.util.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -11,4 +18,16 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+
+    public Long save(SignUpDto signUpDto) {
+
+        Optional<User> findUser = userRepository.findByEmail(signUpDto.getEmail());
+
+        if(!findUser.isEmpty())
+            throw new CustomException(ErrorCode.USER_EMAIL_DUPLICATED);
+
+        User savedUser = userRepository.saveAndFlush(new User(signUpDto.getEmail(), signUpDto.getPassword(), signUpDto.getPhone(), ROLE.USER));
+
+        return savedUser.getUserId();
+    }
 }

--- a/src/main/java/C1S/childgoodsstore/util/ApiResponse.java
+++ b/src/main/java/C1S/childgoodsstore/util/ApiResponse.java
@@ -1,0 +1,37 @@
+package C1S.childgoodsstore.util;
+
+
+import org.springframework.http.HttpStatus;
+public class ApiResponse<T> {
+
+    private String code;
+    private T data;
+
+    public ApiResponse(String code, T data) {
+        this.code = code;
+        this.data = data;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public void setData(T data) {
+        this.data = data;
+    }
+
+    // 성공 응답 생성
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(String.valueOf(HttpStatus.OK.value()), data);
+    }
+
+}
+

--- a/src/main/java/C1S/childgoodsstore/util/exception/CustomException.java
+++ b/src/main/java/C1S/childgoodsstore/util/exception/CustomException.java
@@ -1,0 +1,23 @@
+package C1S.childgoodsstore.util.exception;
+
+public class CustomException extends RuntimeException{
+
+    private final ErrorCode code;
+
+    public CustomException(ErrorCode code, String message){
+        super(code.getMessage() + "("+message + ")");
+        this.code = code ;
+    }
+    public CustomException(ErrorCode code){
+        super(code.getMessage());
+        this.code = code;
+    }
+    @Override
+    public String getMessage() {
+        return super.getMessage();
+    }
+
+    public ErrorCode getCode(){
+        return this.code;
+    }
+}

--- a/src/main/java/C1S/childgoodsstore/util/exception/ErrorCode.java
+++ b/src/main/java/C1S/childgoodsstore/util/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package C1S.childgoodsstore.util.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    //user
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "6404", "해당 사용자가 존재하지 않습니다."),
+    USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "6409", "해당 이메일이 이미 존재합니다"),
+    USER_EMAIL_MISMATCH(HttpStatus.BAD_REQUEST,"6400", "해당 이메일을 가진 사용자가 없습니다."),
+    USER_NAME_EMAIL_MISMATCH(HttpStatus.BAD_REQUEST,"6400", "해당 이메일, 이름을 가진 사용자가 없습니다."),
+    OTP_MISMATCH(HttpStatus.BAD_REQUEST,"6400", "인증 번호가 틀렸습니다."),
+    OTP_NOT_FOUND(HttpStatus.NOT_FOUND,"6404", "인증 번호가 만료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/C1S/childgoodsstore/util/exception/ErrorCode.java
+++ b/src/main/java/C1S/childgoodsstore/util/exception/ErrorCode.java
@@ -9,12 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     //user
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "6404", "해당 사용자가 존재하지 않습니다."),
-    USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "6409", "해당 이메일이 이미 존재합니다"),
-    USER_EMAIL_MISMATCH(HttpStatus.BAD_REQUEST,"6400", "해당 이메일을 가진 사용자가 없습니다."),
-    USER_NAME_EMAIL_MISMATCH(HttpStatus.BAD_REQUEST,"6400", "해당 이메일, 이름을 가진 사용자가 없습니다."),
-    OTP_MISMATCH(HttpStatus.BAD_REQUEST,"6400", "인증 번호가 틀렸습니다."),
-    OTP_NOT_FOUND(HttpStatus.NOT_FOUND,"6404", "인증 번호가 만료되었습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "404", "해당 사용자가 존재하지 않습니다."),
+    USER_EMAIL_DUPLICATED(HttpStatus.CONFLICT, "409", "해당 이메일이 이미 존재합니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/C1S/childgoodsstore/util/exception/ErrorResponse.java
+++ b/src/main/java/C1S/childgoodsstore/util/exception/ErrorResponse.java
@@ -1,0 +1,25 @@
+package C1S.childgoodsstore.util.exception;
+
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class ErrorResponse<T> {
+
+    private String code;
+    private String message;
+    private T data;
+
+    @Builder
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+        this.data = null;
+    }
+}

--- a/src/main/java/C1S/childgoodsstore/util/exception/GlobalExceptionHandler.java
+++ b/src/main/java/C1S/childgoodsstore/util/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package C1S.childgoodsstore.util.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(value = CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException( CustomException e){
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .code(e.getCode().getCode())
+                .message(e.getMessage())
+                .build();
+        return ResponseEntity.status(e.getCode().getStatus())
+                .body(errorResponse);
+    }
+
+
+
+
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+
+#AWS
+spring.datasource.url=jdbc:mysql://localhost:3306/childdb?characterEncoding=utf8
+spring.datasource.username=root
+spring.datasource.password=Mynaver1sql!
+spring.jpa.hibernate.ddl-auto=create

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,7 @@ spring.datasource.url=jdbc:mysql://localhost:3306/childdb?characterEncoding=utf8
 spring.datasource.username=root
 spring.datasource.password=Mynaver1sql!
 spring.jpa.hibernate.ddl-auto=create
+
+#JPA log
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.orm.jdbc.bind=TRACE


### PR DESCRIPTION
## TITLE
자체 회원가입, 자체 로그인, 성공 및 에러 응답 통일

## 개요
자체 회원가입, 자체 로그인(spring security) 구현 완료했습니다.
현재는 jwt만 사용하여 로그인하는 방식이고, 추후에 refreshToken을 추가할 예정입니다.

ApiResponse를 정의해서 컨트롤러에서 성공 응답을 통일할 수 있게 했습니다.
CustomException을 정의해서 에러 처리 단계에서 에러 응답을 통일하고, code와 message를 지정할 수 있게 했습니다.


## 연관된 이슈
#1 

## 변경사항 및 이유
- email, password, phoneNum으로 회원가입
- email, password로 spring security 로그인
- 성공 응답 통일
- 에러 응답 통일

## 리뷰 요구사항(선택)
> ROLE을 USER, ADMIN으로 구분했습니다. ROLE에 따라 접근 가능한 api를 제한할 것이 있을까요? 추가적으로 필요한 ROLE에 대한 의견을 주셔도 좋을 거 같습니다.
> ApiResponse와 CustomException으로 응답을 통일했습니다. 이 외에 다른 방법 알고 계신 것이 있을까요?
