### PR TITLE
Fix: 중고 상품 조회 (api 106)에서 채팅방 id 반환 추가

### DIFF
--- a/src/main/java/C1S/childgoodsstore/chatting/repository/ChattingRoomRepository.java
+++ b/src/main/java/C1S/childgoodsstore/chatting/repository/ChattingRoomRepository.java
@@ -1,6 +1,7 @@
 package C1S.childgoodsstore.chatting.repository;
 
 import C1S.childgoodsstore.entity.ChattingRoom;
+import C1S.childgoodsstore.entity.Product;
 import C1S.childgoodsstore.entity.Together;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +23,6 @@ public interface ChattingRoomRepository extends JpaRepository<ChattingRoom, Long
     @Transactional
     @Query("UPDATE ChattingRoom r SET r.userCount = r.userCount + 1 WHERE r.chatRoomId = :chatRoomId")
     void upUserCount(@Param("chatRoomId") Long chatRoomId);
+
+    List<ChattingRoom> findAllByProduct(Product product);
 }

--- a/src/main/java/C1S/childgoodsstore/chatting/repository/ChattingRoomUserRepository.java
+++ b/src/main/java/C1S/childgoodsstore/chatting/repository/ChattingRoomUserRepository.java
@@ -18,9 +18,11 @@ public interface ChattingRoomUserRepository extends JpaRepository<ChattingRoomUs
 
     @Query("select c from ChattingRoomUser c where c.chattingRoom = :chattingRoom and c.user = :user")
     ChattingRoomUser findByChatRoomAndUser(@Param("chattingRoom") ChattingRoom chattingRoom,
-                                             @Param("user") User user);
+                                           @Param("user") User user);
 
     @Modifying
     @Query("update ChattingRoomUser c set c.user = null where c.user = :user")
     void deleteByUser(@Param("user") User user);
+
+    ChattingRoomUser findByUserAndChattingRoom(User user, ChattingRoom chattingRoom);
 }

--- a/src/main/java/C1S/childgoodsstore/product/dto/output/ProductDetailsDto.java
+++ b/src/main/java/C1S/childgoodsstore/product/dto/output/ProductDetailsDto.java
@@ -31,6 +31,7 @@ public class ProductDetailsDto {
     private List<String> tag;
     private List<String> productImage;
     private boolean productHeart;
+    private Long chatRoomId;
 
     // UserDto 내부 클래스
     @Getter
@@ -50,9 +51,9 @@ public class ProductDetailsDto {
     }
 
     public ProductDetailsDto(Long productId, UserDto user, String productName, int price, String content,
-                      MAIN_CATEGORY mainCategory, SUB_CATEGORY subCategory, AGE age, PRODUCT_STATE productState,
-                      PRODUCT_SALE_STATUS state, LocalDateTime createdAt, LocalDateTime updatedAt,
-                      List<String> tag, List<String> productImage, boolean productHeart) {
+                             MAIN_CATEGORY mainCategory, SUB_CATEGORY subCategory, AGE age, PRODUCT_STATE productState,
+                             PRODUCT_SALE_STATUS state, LocalDateTime createdAt, LocalDateTime updatedAt,
+                             List<String> tag, List<String> productImage, boolean productHeart, Long chatRoomId) {
         this.productId = productId;
         this.user = user;
         this.productName = productName;
@@ -68,9 +69,10 @@ public class ProductDetailsDto {
         this.tag = tag;
         this.productImage = productImage;
         this.productHeart = productHeart;
+        this.chatRoomId = chatRoomId;
     }
 
-    public static ProductDetailsDto fromProduct(Product product, boolean productHeart) {
+    public static ProductDetailsDto fromProduct(Product product, boolean productHeart, Long chatRoomId) {
         UserDto userDto = new UserDto(
                 product.getUser().getUserId(),
                 product.getUser().getNickName(),
@@ -93,7 +95,8 @@ public class ProductDetailsDto {
                 product.getUpdatedAt(),
                 extractTags(product),
                 extractProductImages(product),
-                productHeart
+                productHeart,
+                chatRoomId
         );
     }
 

--- a/src/main/java/C1S/childgoodsstore/product/service/ProductService.java
+++ b/src/main/java/C1S/childgoodsstore/product/service/ProductService.java
@@ -186,8 +186,19 @@ public class ProductService {
         // ProductHeart 존재 여부 확인
         boolean hasHeart = productHeartRepository.existsByUserAndProduct(user, product);
 
+        // 중고 상품으로 생성된 채팅방 조회
+        List<ChattingRoom> chattingRooms = chattingRoomRepository.findAllByProduct(product);
+
+        // 사용자가 참여한 채팅방 ID 찾기
+        for (ChattingRoom chattingRoom : chattingRooms) {
+            ChattingRoomUser chattingRoomUser = chattingRoomUserRepository.findByUserAndChattingRoom(user, chattingRoom);
+            if (chattingRoomUser != null) {
+                // 사용자가 참여한 채팅방 ID와 함께 DTO 반환
+                return ProductDetailsDto.fromProduct(product, hasHeart, chattingRoomUser.getChatRoomUserId());
+            }
+        }
         // ProductDto 생성 및 반환
-        return ProductDetailsDto.fromProduct(product, hasHeart);
+        return ProductDetailsDto.fromProduct(product, hasHeart, null);
     }
 
     // controller - 홈화면 상품 목록 조회


### PR DESCRIPTION
## TITLE
중고 상품 조회 (api 106)에서 채팅방 id 반환 추가

## 개요
중고 상품 상세 조회 반환에 채팅방 id 추가했습니다.

## 연관된 이슈
> #14 

## 변경사항 및 이유
유저가 이미 해당 중고 상품으로 채팅을 시작한 상태이면 기존 채팅방으로 입장해야 하기 채팅방 id 반환을 추가했습니다.

