### PR TITLE
Fix: 프로필에서 공동구매 이미지 반환형 리스트에서 문자열로 변경

### DIFF
--- a/src/main/java/C1S/childgoodsstore/profile/dto/TogetherDto.java
+++ b/src/main/java/C1S/childgoodsstore/profile/dto/TogetherDto.java
@@ -15,10 +15,10 @@ public class TogetherDto {
     private Integer totalNum;
     private Integer purchaseNum;
     private LocalDateTime deadline;
-    private List<String> togetherImage;
+    private String togetherImage;
     private Boolean togetherHeart;
 
-    public static TogetherDto fromEntity(Together together, List<String> togetherImage) {
+    public static TogetherDto fromEntity(Together together, String togetherImage) {
         TogetherDto dto = new TogetherDto();
         dto.setTogetherId(together.getTogetherId());
         dto.setTogetherName(together.getTogetherName());

--- a/src/main/java/C1S/childgoodsstore/profile/service/ProfileService.java
+++ b/src/main/java/C1S/childgoodsstore/profile/service/ProfileService.java
@@ -120,11 +120,12 @@ public class ProfileService {
         // Together 객체들을 TogetherDto로 변환
         return togethers.getContent().stream()
                 .map(together -> {
-                    List<String> imageUrls = togetherImageRepository.findById(together.getTogetherId())
+                    String imageUrl = togetherImageRepository.findById(together.getTogetherId())
                             .stream()
                             .map(TogetherImage::getImageUrl)
-                            .collect(Collectors.toList());
-                    return TogetherDto.fromEntity(together, imageUrls);
+                            .findFirst() // Optional<String>을 반환
+                            .orElse(null); // Optional이 비어 있으면 null 반환
+                    return TogetherDto.fromEntity(together, imageUrl);
                 })
                 .collect(Collectors.toList());
     }
@@ -137,11 +138,12 @@ public class ProfileService {
         // 변환: Entity를 DTO로
         return togethers.getContent().stream()
                 .map(together -> {
-                    List<String> imageUrls = togetherImageRepository.findById(together.getTogetherId())
+                    String imageUrl = togetherImageRepository.findById(together.getTogetherId())
                             .stream()
                             .map(TogetherImage::getImageUrl)
-                            .collect(Collectors.toList());
-                    return TogetherDto.fromEntity(together, imageUrls);
+                            .findFirst() // Optional<String>을 반환
+                            .orElse(null); // Optional이 비어 있으면 null 반환
+                    return TogetherDto.fromEntity(together, imageUrl);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## TITLE

## 개요
프로필에서 공동구매 이미지 반환형 List<String>에서 String으로 변경했습니다.

## 연관된 이슈
> #54 

## 변경사항 및 이유
프로필에서는 첫번째 이미지만 대표 이미지로 띄우기 때문에 리스트 반환형에서 첫번째 이미지 url 하나만 반환하도록 수정했습니다. 

## 리뷰 요구사항(선택)
@wjlee611 수정 완료했습니다.
